### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@ django-futupayments
 ===================
 
 [![Build Status](https://travis-ci.org/Futubank/django-futupayments.svg?branch=master)](https://travis-ci.org/Futubank/django-futupayments)
-[![Latest Version](https://pypip.in/version/django-futupayments/badge.svg?text=version)](https://pypi.python.org/pypi/django-futupayments/)
-[![Supported Python versions](https://pypip.in/py_versions/django-futupayments/badge.svg)](https://pypi.python.org/pypi/django-futupayments/)
-[![Development Status](https://pypip.in/status/django-futupayments/badge.svg)](https://pypi.python.org/pypi/django-futupayments/)
+[![Latest Version](https://img.shields.io/pypi/v/django-futupayments.svg?label=version)](https://pypi.python.org/pypi/django-futupayments/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/django-futupayments.svg)](https://pypi.python.org/pypi/django-futupayments/)
+[![Development Status](https://img.shields.io/pypi/status/django-futupayments.svg)](https://pypi.python.org/pypi/django-futupayments/)
 [![Supported Django versions](http://img.shields.io/badge/Django-1.3,%201.4,%201.5,%201.6,%201.7-green.svg)](https://travis-ci.org/Futubank/django-futupayments)
 
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-futupayments))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-futupayments`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.